### PR TITLE
feat: Add campaign_insights stream

### DIFF
--- a/nekt.config.json
+++ b/nekt.config.json
@@ -56,13 +56,23 @@
             "el_type": "extractor",
             "description": "Allows the selection of breakdown reports, such as gender, country, age and device platform. Should be used with caution since the extraction time can increase significantly."
           },
+          "enable_campaign_insights": {
+            "type": "boolean",
+            "order": 5,
+            "title": "Enable campaign-level insights",
+            "default": false,
+            "el_type": "extractor",
+            "description": "Enables the campaign insights stream, which provides insights aggregated at the campaign level instead of the ad level. Produces significantly fewer rows and faster extractions.",
+            "advanced_settings": true
+          },
           "performance_granularity": {
             "type": "string",
-            "order": 5,
+            "order": 6,
             "title": "Insights granularity",
             "format": "dropdown",
             "default": "daily",
             "el_type": "extractor",
+            "advanced_settings": true,
             "description": "Time granularity for all insight streams (adsinsights and breakdown variants). 'Daily' returns one row per day, 'Monthly' aggregates metrics by calendar month for faster extractions on large date ranges.",
             "allowed_values": [
               {
@@ -77,7 +87,7 @@
           },
           "ad_insights_report_batch_size": {
             "type": "integer",
-            "order": 6,
+            "order": 7,
             "title": "Ad Insights batch size",
             "default": 30,
             "el_type": "extractor",
@@ -86,7 +96,7 @@
           },
           "report_definition": {
             "type": "object",
-            "order": 7,
+            "order": 8,
             "format": "parent",
             "el_type": "extractor",
             "required": [

--- a/tap_facebook/streams/__init__.py
+++ b/tap_facebook/streams/__init__.py
@@ -10,6 +10,7 @@ from tap_facebook.streams.ad_insights import (
     AdsInsightByRegionStream,
     AdsInsightHourlyAdvertiserTimezoneStream,
     AdsInsightStream,
+    CampaignInsightsStream,
 )
 from tap_facebook.streams.ad_labels import AdLabelsStream
 from tap_facebook.streams.ad_videos import AdVideos
@@ -31,6 +32,7 @@ __all__ = [
     "AdsInsightByCountryStream",
     "AdsInsightByDevicePlatformStream",
     "AdsInsightByRegionStream",
+    "CampaignInsightsStream",
     "AdsStream",
     "AdVideos",
     "CampaignStream",

--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -233,6 +233,11 @@ class AdsInsightStream(FacebookSDKStream):
         }
 
     @property
+    def report_level(self) -> str:
+        """Return the aggregation level for the insights report."""
+        return self.config.get("report_definition", {}).get("level", "ad")
+
+    @property
     def report_breakdowns(self) -> list[str] | None:
         return self.config.get("report_definition", {}).get("breakdowns")
 
@@ -353,7 +358,7 @@ class AdsInsightStream(FacebookSDKStream):
                 break
 
             params = {
-                "level": self.config.get("report_definition", {}).get("level"),
+                "level": self.report_level,
                 "action_breakdowns": self.config.get("report_definition", {}).get("action_breakdowns"),
                 "action_report_time": self.config.get("report_definition", {}).get("action_report_time"),
                 "breakdowns": self.report_breakdowns,
@@ -654,3 +659,30 @@ class AdsInsightByHourStream(AdsInsightStream):
     @property
     def report_breakdowns(self) -> list[str] | None:
         return ["region"]
+
+
+class CampaignInsightsStream(AdsInsightStream):
+    """Insights aggregated at the campaign level.
+
+    Unlike the default AdsInsightStream (level=ad), this stream returns one row
+    per campaign per time period, producing significantly fewer rows and faster
+    extractions for accounts with many ads.
+    """
+
+    name = "campaign_insights"
+
+    @property
+    def report_level(self) -> str:
+        return "campaign"
+
+    def _generate_hash_id(self, adinsight: AdsInsights, report_breakdowns: list[str]):
+        date_start = adinsight.get("date_start", "")
+        campaign_id = adinsight.get("campaign_id", "")
+
+        breakdown_values = []
+        for breakdown in report_breakdowns:
+            breakdown_values.append(str(adinsight.get(breakdown, "")))
+        breakdown_string = "-".join(breakdown_values)
+
+        hash_object = md5(f"{date_start}-{campaign_id}-{breakdown_string}".encode())
+        return hash_object.hexdigest()

--- a/tap_facebook/tap.py
+++ b/tap_facebook/tap.py
@@ -24,6 +24,7 @@ from tap_facebook.streams import (
     AdsInsightStream,
     AdsStream,
     AdVideos,
+    CampaignInsightsStream,
     CampaignStream,
     CreativeStream,
     CustomAudiences,
@@ -222,6 +223,16 @@ class TapFacebook(Tap):
             default="daily",
         ),
         th.Property(
+            "enable_campaign_insights",
+            th.BooleanType,
+            default=False,
+            description=(
+                "Enable the campaign_insights stream, which provides insights aggregated "
+                "at the campaign level instead of the ad level. Produces significantly fewer "
+                "rows and faster extractions for accounts with many ads."
+            ),
+        ),
+        th.Property(
             "creative_thumbnail_width",
             th.IntegerType,
             description="The width for creative thumbnails.",
@@ -242,6 +253,9 @@ class TapFacebook(Tap):
             A list of discovered streams.
         """
         streams = [stream_class(tap=self) for stream_class in STREAM_TYPES]
+
+        if self.config.get("enable_campaign_insights", False):
+            streams.append(CampaignInsightsStream(tap=self))
 
         advanced_streams = []
         if self.config.get("enable_advanced_reports", False):


### PR DESCRIPTION
## Summary
- Adds `campaign_insights` stream (insights aggregated at campaign level)
- Gated behind `enable_campaign_insights` boolean config (default false)
- Extracts `report_level` as overridable property for cleaner subclassing

Follows up on #4 (performance_granularity).

## Test plan
- [x] Verified stream hidden when flag is off
- [x] Verified stream appears when flag is on
- [x] Tested extraction with monthly granularity against live API

🤖 Generated with [Claude Code](https://claude.com/claude-code)